### PR TITLE
Erroneous "source" argument passed instead of "src", causes nix flake check failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       in rec {
         packages.tree-sitter-norg-meta = grammar {
           language = "norg-meta";
-          source = ./.;
+          src = ./.;
           inherit (pkgs.tree-sitter) version;
         };
         defaultPackage = packages.tree-sitter-norg-meta;


### PR DESCRIPTION
```

       … from call site
         at /nix/store/h2bn031b0fj0ymv9v7bv5rcdjx58y2l9-source/lib/trivial.nix:989:5:
          988|     # TODO: Should we add call-time "type" checking like built in?
          989|     __functor = self: f;
             |     ^
          990|     __functionArgs = args;

       error: function 'anonymous lambda' called without required argument 'src'
       at /nix/store/h2bn031b0fj0ymv9v7bv5rcdjx58y2l9-source/pkgs/development/tools/parsing/tree-sitter/grammar.nix:10:1:
            9|
           10| {
             | ^
           11|   # language name
```

This occurs for both tree-sitter-norg-meta and tree-sitter-norg/dev. A similar PR will be made there. I hope this otherwise has no adverse effects for users, but as it stands, the use of https://github.com/nvim-neorg/nixpkgs-neorg-overlay/ currently causes `nix flake check` to fail for me.